### PR TITLE
Fix: Ignore Case for Error Checking

### DIFF
--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -127,7 +127,7 @@ func testCheckLabelMap(name string, partialKey string, expectedLabels map[string
 // message to ignore. Returns true if so, false otherwise (also if no ignorable message is given)
 func containsIgnorableErrorMessage(errorMsg string, ignorableErrorMessages ...string) bool {
 	for _, ignorableErrorMessage := range ignorableErrorMessages {
-		if strings.Contains(errorMsg, ignorableErrorMessage) {
+		if strings.Contains(strings.ToLower(errorMsg), strings.ToLower(ignorableErrorMessage)) {
 			return true
 		}
 	}


### PR DESCRIPTION
Podman outputs "no such container" in all lowercase. To Fix the issue I simply convert all strings that are checked by containsIgnorableErrorMessage() to lowercase making the method case insensitive.